### PR TITLE
update github workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: rustup component add clippy
-    - uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features --workspace -- -D warnings
+    - run: cargo clippy --all-targets --all-features --workspace -- -Dwarnings

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
     - name: Prepare
       run: pip install sphinx sphinx_rtd_theme

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   upload:
     runs-on: ubuntu-latest 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: diode-send,diode-receive,diode-send-file,diode-receive-file
+          bin: diode-send,diode-receive,diode-send-file,diode-receive-file,diode-send-udp,diode-receive-udp
           archive: lidi-$tag
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose --workspace


### PR DESCRIPTION
### Description

In this pull request, we are updating the GitHub Actions workflows for clippy, documentation, release, and Rust builds to make improvements and ensure better practices are followed. 

Below are the summarized changes based on the code diffs:

- In the clippy workflow:
  - Updated the action checkout version to v4.
  - Replaced the clippy-check action with a direct cargo clippy command for better optimization.

- In the doc workflow:
  - Updated the action checkout version to v4.

- In the release workflow:
  - Updated the action checkout version to v4.

- In the rust workflow:
  - Updated the action checkout version to v4.
  - Added new binaries diode-send-udp and diode-receive-udp to the upload step.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update GitHub workflows to use `actions/checkout@v4`, replace `actions-rs/clippy-check@v1` with a direct `cargo clippy` command, and add new binaries `diode-send-udp` and `diode-receive-udp` to the release upload step.

### Why are these changes being made?

These changes ensure compatibility with the latest version of the checkout action, streamline the clippy linting process by removing an external action, and expand the release process to include additional binaries, enhancing the functionality and maintainability of the workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->